### PR TITLE
Add control panel and plugin upload system

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ This project is a multi-page web application that converts uploaded CSV or SRT s
 - Props and LoRA configuration
 - Mobile-first responsive layout using Bootstrap 5
 
+## Control Panel and Custom Modules
+- `control-panel.html` provides toggles for enabling or disabling categories, modules, and individual features.
+- Users can upload custom HTML, CSS, or JavaScript files. Uploaded files are served from `/develop` and can register new modules by calling `registerModule` from `src/js/moduleManager.js`.
+
 ## Development
 1. Run `./setup.sh` to install dependencies and set the Replicate API key.
 2. Access the app at [http://localhost:3000](http://localhost:3000).

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "express": "^4.18.2",
+    "multer": "^1.4.5-lts.1",
     "node-fetch": "^2.6.9"
   }
 }

--- a/public/control-panel.html
+++ b/public/control-panel.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Control Panel</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1>AI Film Studio Control Panel</h1>
+  <div id="control-panel"></div>
+
+  <h2>Upload Custom Module</h2>
+  <form id="upload-form">
+    <input type="file" id="module-file" multiple />
+    <button type="submit">Upload</button>
+  </form>
+
+  <script type="module" src="/src/js/controlPanel.js"></script>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -2,6 +2,8 @@ import express from 'express';
 import fetch from 'node-fetch';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import fs from 'fs';
+import multer from 'multer';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -10,6 +12,19 @@ const app = express();
 app.use(express.json({ limit: '10mb' }));
 app.use(express.static(path.join(__dirname, 'public')));
 app.use('/src', express.static(path.join(__dirname, 'src')));
+
+const uploadDir = path.join(__dirname, 'public', 'develop');
+if (!fs.existsSync(uploadDir)) fs.mkdirSync(uploadDir, { recursive: true });
+
+const storage = multer.diskStorage({
+  destination: uploadDir,
+  filename: (req, file, cb) => cb(null, file.originalname)
+});
+const upload = multer({ storage });
+
+app.post('/api/upload-module', upload.array('files'), (req, res) => {
+  res.json({ files: req.files.map(f => f.filename) });
+});
 
 app.post('/api/shot-breakdown', async (req, res) => {
   const { lines, textModel, apiKey } = req.body;

--- a/src/js/controlPanel.js
+++ b/src/js/controlPanel.js
@@ -1,0 +1,95 @@
+import { registerModule, getRegistry, toggleFeature, toggleModule, loadScript } from './moduleManager.js';
+
+// Register default modules and features
+registerModule('2D Animation', 'Scriptwriting', [
+  'Generate Script',
+  'Rewrite Script',
+  'Character Generation',
+  'Dialogue Generation'
+]);
+registerModule('2D Animation', 'Character Design', [
+  'Generate Characters',
+  'Customizable Features',
+  'Character Expressions'
+]);
+registerModule('2D Animation', 'Animation', [
+  'Auto Animation',
+  'Background Generation',
+  'Frame Generation'
+]);
+registerModule('3D Animation', '3D Modelling', [
+  'Model Generation',
+  'Motion Capture',
+  'Rendering'
+]);
+registerModule('Live Action Filmmaking', 'Pre-Production', [
+  'Storyboarding',
+  'Location Scouting'
+]);
+registerModule('Live Action Filmmaking', 'Post-Production', [
+  'Color Grading',
+  'Special Effects'
+]);
+
+const container = document.getElementById('control-panel');
+const registry = getRegistry();
+
+for (const [category, modules] of Object.entries(registry)) {
+  const catDiv = document.createElement('div');
+  const catHeader = document.createElement('h2');
+  catHeader.textContent = category;
+  catDiv.appendChild(catHeader);
+
+  for (const [module, data] of Object.entries(modules)) {
+    const modDiv = document.createElement('div');
+    const modHeader = document.createElement('h3');
+    modHeader.textContent = module;
+    const modToggle = document.createElement('input');
+    modToggle.type = 'checkbox';
+    modToggle.checked = data.enabled;
+    modToggle.addEventListener('change', e => toggleModule(category, module, e.target.checked));
+    modHeader.prepend(modToggle);
+    modDiv.appendChild(modHeader);
+
+    data.features.forEach(feature => {
+      const label = document.createElement('label');
+      label.style.display = 'block';
+      const checkbox = document.createElement('input');
+      checkbox.type = 'checkbox';
+      checkbox.checked = feature.enabled;
+      checkbox.addEventListener('change', e => toggleFeature(category, module, feature.name, e.target.checked));
+      label.appendChild(checkbox);
+      label.appendChild(document.createTextNode(' ' + feature.name));
+      modDiv.appendChild(label);
+    });
+    catDiv.appendChild(modDiv);
+  }
+  container.appendChild(catDiv);
+}
+
+// Upload custom modules
+const uploadForm = document.getElementById('upload-form');
+uploadForm.addEventListener('submit', async e => {
+  e.preventDefault();
+  const files = document.getElementById('module-file').files;
+  if (!files.length) return;
+  const formData = new FormData();
+  [...files].forEach(f => formData.append('files', f));
+  const res = await fetch('/api/upload-module', {
+    method: 'POST',
+    body: formData
+  });
+  if (res.ok) {
+    const { files: uploaded } = await res.json();
+    // Dynamically load uploaded scripts
+    for (const f of uploaded) {
+      if (f.endsWith('.js')) {
+        await loadScript(`/develop/${f}`);
+      }
+    }
+    alert('Uploaded');
+  } else {
+    alert('Upload failed');
+  }
+  uploadForm.reset();
+});

--- a/src/js/moduleManager.js
+++ b/src/js/moduleManager.js
@@ -1,0 +1,33 @@
+const registry = {};
+
+export function registerModule(category, module, features = []) {
+  if (!registry[category]) registry[category] = {};
+  registry[category][module] = {
+    enabled: true,
+    features: features.map(name => ({ name, enabled: true }))
+  };
+}
+
+export function toggleFeature(category, module, feature, state) {
+  const mod = registry[category]?.[module];
+  if (!mod) return;
+  const f = mod.features.find(f => f.name === feature);
+  if (f) f.enabled = state;
+}
+
+export function toggleModule(category, module, state) {
+  const mod = registry[category]?.[module];
+  if (mod) mod.enabled = state;
+}
+
+export function toggleCategory(category, state) {
+  if (registry[category]) registry[category].enabled = state;
+}
+
+export function getRegistry() {
+  return registry;
+}
+
+export async function loadScript(url) {
+  await import(url);
+}


### PR DESCRIPTION
## Summary
- Introduce client-side module registry for dynamic categories and features
- Add control panel page with feature toggles and custom module uploads
- Support server-side storage of uploaded modules via Multer

## Testing
- `npm install` *(fails: 403 Forbidden when fetching packages)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a876ece65883329d911049d7cdf61a